### PR TITLE
Set up simple server with a route to fetch hyperterm plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "hyperterm_plugins",
   "version": "0.0.1",
   "dependencies": {
+    "express": "^4.14.0",
+    "got": "^6.3.0",
+    "npm-keyword": "^4.2.0",
     "react": "^15.2.1",
     "react-dom": "^15.2.1"
   }

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const npmKeyword = require('npm-keyword');
+const got = require('got');
+
+const app = express();
+
+app.get('/plugins', (req, res) => {
+  npmKeyword('hyperterm').then((packages) => {
+    Promise.all(packages.map((package) => {
+      return got(`http://registry.npmjs.org/${package.name}`).then((response) => {
+        return JSON.parse(response.body);
+      });
+    })).then((packages) => {
+      res.send(packages);
+    });
+  });
+});
+
+app.listen(3000, () => {
+  console.log('Listening on port 3000!');
+});


### PR DESCRIPTION
This is still super naive, maybe we can cache the response for some time since it takes a while because of doing a N+1 query to get all the package details.

Also, what do you think about the folder structure? should `server` be inside of `src`?
