### PR TITLE
Change the server to be a graphql server

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
   "name": "hyperterm_plugins",
   "version": "0.0.1",
   "dependencies": {
+    "apollo-server": "^0.1.5",
     "express": "^4.14.0",
     "got": "^6.3.0",
+    "graphql": "^0.6.2",
     "npm-keyword": "^4.2.0",
     "react": "^15.2.1",
     "react-dom": "^15.2.1"

--- a/server/data/resolvers.js
+++ b/server/data/resolvers.js
@@ -1,0 +1,27 @@
+const npmKeyword = require('npm-keyword');
+const got = require('got');
+
+const findPlugins = () => {
+  return npmKeyword('hyperterm').then((packages) => {
+    return Promise.all(packages.map((package) => {
+      return got(`http://registry.npmjs.org/${package.name}`).then((response) => {
+        return JSON.parse(response.body);
+      });
+    }));
+  });
+};
+
+const resolvers = {
+  Query: {
+    plugins(root, args) {
+      return findPlugins();
+    }
+  },
+  Plugin: {
+    id(root) {
+      return root._id;
+    }
+  }
+};
+
+module.exports = resolvers;

--- a/server/data/schema.js
+++ b/server/data/schema.js
@@ -1,0 +1,16 @@
+const typeDefinitions = `
+type Plugin {
+  id: String!
+  name: String!
+  description: String
+  homepage: String
+}
+type Query {
+  plugins: [Plugin]
+}
+schema {
+  query: Query
+}
+`;
+
+module.exports = [typeDefinitions];

--- a/server/index.js
+++ b/server/index.js
@@ -1,21 +1,19 @@
 const express = require('express');
-const npmKeyword = require('npm-keyword');
-const got = require('got');
+const { apolloServer } = require('apollo-server');
+const Schema = require('./data/schema');
+const Resolvers = require('./data/resolvers');
+
+const PORT = 8080;
 
 const app = express();
 
-app.get('/plugins', (req, res) => {
-  npmKeyword('hyperterm').then((packages) => {
-    Promise.all(packages.map((package) => {
-      return got(`http://registry.npmjs.org/${package.name}`).then((response) => {
-        return JSON.parse(response.body);
-      });
-    })).then((packages) => {
-      res.send(packages);
-    });
-  });
-});
+app.use('/graphql', apolloServer({
+  graphiql: true,
+  pretty: true,
+  schema: Schema,
+  resolvers: Resolvers
+}));
 
-app.listen(3000, () => {
-  console.log('Listening on port 3000!');
+app.listen(PORT, () => {
+  console.log(`Server is now running on http://localhost:${PORT}/graphql`);
 });


### PR DESCRIPTION
Adding `apollo-server` which provides an easy way to serve and define the graphql schema.

Adding some fields to the plugin schema to start with.

<img width="1280" alt="screen shot 2016-07-29 at 6 43 40 pm" src="https://cloud.githubusercontent.com/assets/328001/17264302/6c922f32-55bc-11e6-86eb-c17317ab6a27.png">
